### PR TITLE
dglaude titano detect

### DIFF
--- a/Adafruit pyportal titano/basicparser.py
+++ b/Adafruit pyportal titano/basicparser.py
@@ -37,14 +37,29 @@ graphic = displayio.Group()
 pixels = neopixel.NeoPixel(board.NEOPIXEL, 1)
 pixels[0] = 0x000000 #set neopixel to black
 light = analogio.AnalogIn(board.LIGHT)
-ts = adafruit_touchscreen.Touchscreen(
-    board.TOUCH_XL,
-    board.TOUCH_XR,
-    board.TOUCH_YD,
-    board.TOUCH_YU,
-    calibration=((5200, 59000), (5800, 57000)),
-    size=(480, 320),
-)
+
+import os
+isTitano = os.uname().machine.find("Titano") != -1
+
+if isTitano:
+    ts = adafruit_touchscreen.Touchscreen(
+        board.TOUCH_XL,
+        board.TOUCH_XR,
+        board.TOUCH_YD,
+        board.TOUCH_YU,
+        calibration=((5200, 59000), (5800, 57000)),
+        size=(480, 320),
+    )
+else:
+    ts = adafruit_touchscreen.Touchscreen(
+        board.TOUCH_XL,
+        board.TOUCH_XR,
+        board.TOUCH_YD,
+        board.TOUCH_YU,
+        calibration=((5200, 59000), (5800, 57000)),
+        size=(320, 240),
+    )
+
 note = {'C1':32,
     'C#1':34,
     'D1':36,

--- a/Adafruit pyportal titano/code.py
+++ b/Adafruit pyportal titano/code.py
@@ -14,7 +14,16 @@ Modified by BeBoX. 2021 for Adafruit titano
 on titano
 23 lines of text
 76 columns (usefull for PRINTAT)
+
+Modified by David Glaude. 2021 for detecting and adapting between PyPortal and PyPortal Titano
+on PyPortal and PyPortal Pynt
+17 lines of text
+50 columns (usefull for PRINTAT)
 """
+
+import os
+isTitano = os.uname().machine.find("Titano") != -1
+print("Titano check: ", isTitano)
 
 from basictoken import BASICToken as Token
 from lexer import Lexer
@@ -34,15 +43,16 @@ except:
     print("i2c init problem ...")
     
 try:
-    cardkb = i2c.scan()[0]  # should return 95
-    if cardkb != 95:
+    cardkb = i2c.scan()  # should return a list with a 95 in
+    if 95 in cardkb:     # This trick should work both on PyPortal Titano and
+        cardkb = 95      # and simple PyPortal (that has and additional ADT7410 on I2C bus)
+    else:
         print("!!! Check I2C config: " + str(i2c))
-        print("!!! CardKB not found. I2C device", cardkb,
-              "found instead.")
+        print("!!! CardKB not found. I2C device list:", cardkb)
         exit(1)
 except:
-    i2ckeyboard=False
-    
+    i2ckeyboard=False    
+
 ESC = chr(27)
 NUL = '\x00'
 CR = "\r"
@@ -180,7 +190,8 @@ def InputFromKB(prompt):
 
 def main():
 
-    banner = (
+    if isTitano:
+        banner = (
     """
     ___  _                 _  _    _ __  _  _  _    _               
    / __|(_) _ _  __  _  _ (_)| |_ | '_ \| || || |_ | |_   ___  _ _  
@@ -194,9 +205,30 @@ def main():
   \____\____\____\____\____\____\____\____\____\____\____\____\____\ 
                                                                   
 """)
+    else:
+        banner = (
+    """
+   ___  _                 _  _
+  / __|(_) _ _  __  _  _ (_)| |_
+ | (__ | || '_|/ _|| || || ||  _|
+  \___||_||_|  \__| \_._||_| \__|
+   _ __  _  _  _    _
+  | '_ \| || || |_ | |_   ___  _ _
+  | .__/ \_. ||  _||   \ / _ \| ' \\
+  |_|    |__/  \__||_||_|\___/|_||_|
+    ___  _  _  ___            _
+   | _ \| || || _ ) __ _  ___(_) __
+   |  _/ \_. || _ \/ _` |(_-/| |/ _|
+   |_|   |__/ |___/\__/_|/__/|_|\__|
+  ___________________________________
+  \____\____\____\____\____\____\____\\
+""")
     print(chr(27)+"[2J")
     print(banner)
-    print("        Adafruit PyPortal Titano Edition by BeBoX (c)2021\r\n")
+    if isTitano:
+        print("        Adafruit PyPortal Titano Edition by BeBoX (c)2021\r\n")
+    else:
+        print("Adafruit PyPortal Edition by BeBoX (c)2021\r\n")
     lexer = Lexer()
     program = Program()
     

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Current version work only for Adafruit titano & CardKB for now.
 The [origninal PyBasic](https://github.com/richpl/PyBasic) was designed to work on "Normal Python".
 But microcontrollers avec spécific things like neopixels, touchscreens etc.
 
-The current version is made and developped around the[Adafruit PyPortal Titano](https://learn.adafruit.com/adafruit-pyportal-titano).
+The current version is made and developped around the [Adafruit PyPortal Titano](https://learn.adafruit.com/adafruit-pyportal-titano).
 Why ? 
-Because i have it and because this deveice is enough complete : network, touchscreen, 480x320 color lcd, sound, light sensor, microSD 
+Because I have it and because this device is enough complete : network, touchscreen, 480x320 color lcd, sound, light sensor, microSD 
 if a [m5stack i2c CardKB](https://shop.m5stack.com/products/cardkb-mini-keyboard) is attached to the Pyportal titano, it will be used 
-for input keystroke and that make the device fully usable "On the Road". If there is no keyboard attached, input comme from computer
+for input keystroke and that make the device fully usable "On the Road". If there is no keyboard attached, input come from computer
 over REPL serial interface.
 ![img](https://github.com/beboxos/circuitpython/blob/main/images/pybasic2.jpeg)
 
-Later, will be ported to other devices like WIO terminal, regular pyportal etc... 
+Later, will be ported to other devices like WIO terminal, regular PyPortal etc... 
 
 New commands added : 
 
@@ -54,5 +54,3 @@ Change Log:
 - 22.10.2021 : WAV function let you play a wave sound file
 - 24.10.2021 : Graphic news feature , gscreen, gcls, gline, grect, gtriangle,gprint ...
 - 24.10.2021 : fixed val() function to match Circuitpython. added example.bas to help you manage all new functions
-
-

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 ## Circuitpython version of PyBasic for microcontrollers
 ![img](https://github.com/beboxos/circuitpython/blob/main/images/pybasic1.jpeg)
 
-Current version work only for Adafruit titano & CardKB for now.
+Current version work only for Adafruit PyPortal Titano with or without CardKB.
+It should work on PyPortal and PyPortal Pynt if autodetect code is working.
+
 The [origninal PyBasic](https://github.com/richpl/PyBasic) was designed to work on "Normal Python".
-But microcontrollers avec spécific things like neopixels, touchscreens etc.
+But microcontrollers with specific things like neopixels, touchscreens etc.
 
 The current version is made and developped around the [Adafruit PyPortal Titano](https://learn.adafruit.com/adafruit-pyportal-titano).
 Why ? 
@@ -54,3 +56,5 @@ Change Log:
 - 22.10.2021 : WAV function let you play a wave sound file
 - 24.10.2021 : Graphic news feature , gscreen, gcls, gline, grect, gtriangle,gprint ...
 - 24.10.2021 : fixed val() function to match Circuitpython. added example.bas to help you manage all new functions
+- 02.11.2021 : David Glaude add non Titano PyPortal detection
+


### PR DESCRIPTION
Fix the README and add auto-detection of PyPortal Titano.
Should now work on all PyPortal (but I only have the normal, not Titano, not Pynt).
Graphic and touch not tested... might require some adaptation for screen size.